### PR TITLE
Update devcontainer image version to 0.2.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "kargo-quickstart",
-	"image": "quay.io/akuity/argo-cd-learning-assets/akuity-devcontainer:0.2.4",
+	"image": "quay.io/akuity/argo-cd-learning-assets/akuity-devcontainer:0.2.5",
 
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {


### PR DESCRIPTION
This addresses Kargo CLI incompatibility addressed via https://github.com/akuity/argo-cd-learning-assets/pull/10
<img width="715" height="407" alt="Screenshot 2026-05-28 at 5 05 31 PM" src="https://github.com/user-attachments/assets/69c25316-f5ad-4b7d-9e8b-63e04aa54141" />

